### PR TITLE
Make mapnikify template compatible with latest mapnik/proj version

### DIFF
--- a/lib/template.xml
+++ b/lib/template.xml
@@ -1,4 +1,4 @@
-<Map srs="+init=epsg:3857">
+<Map srs="epsg:3857">
     <Style name="geoms">
         <Rule>
             <Filter>[mapnik::geometry_type]=polygon or [fill]</Filter>
@@ -19,7 +19,7 @@
             />
         </Rule>
     </Style>
-    <Layer name="layer" srs="+init=epsg:4326">
+    <Layer name="layer" srs="epsg:4326">
         <StyleName>geoms</StyleName>
         <StyleName>points</StyleName>
         <Datasource>


### PR DESCRIPTION
While upgrading dependencies as part of the upcoming k8s migration we encountered an incompatibility with geojson overlay map rendering. More specifically because we upgraded geo proj to version >= 6 the config changed and we don't need the +init prefix anymore.

More specifically:
* https://packages.debian.org/bookworm/libproj-dev
* https://proj.org/en/stable/development/migration.html#backward-incompatibilities